### PR TITLE
allow diff for atom keys

### DIFF
--- a/lib/json_diff.ex
+++ b/lib/json_diff.ex
@@ -103,6 +103,10 @@ defmodule JSONDiff do
     Map.has_key?(map, key)
   end
 
+  defp has_key_or_index?(map, key) when is_map(map) and is_atom(key) do
+    Map.has_key?(map, key)
+  end
+
   defp has_key_or_index?(list, index) when is_list(list) and is_integer(index) do
     Enum.at(list, index) != nil
   end
@@ -171,5 +175,9 @@ defmodule JSONDiff do
         path = Regex.replace(~r/~/, path, "~0")
         Regex.replace(~r/\//, path, "~1")
     end
+  end
+
+  def escape_path_component(path) when is_atom(path) do
+    escape_path_component(Atom.to_string(path))
   end
 end

--- a/test/json_diff_test.exs
+++ b/test/json_diff_test.exs
@@ -236,4 +236,15 @@ defmodule JSONDiffTest do
 
     assert {:ok, ^b} = JSONPatch.patch(a, patches)
   end
+
+  test "it should diff for atom keys" do 
+    a = %{a: 1}
+    b = %{a: 2}
+    
+    patches = diff(a, b)
+    assert patches == [ %{"op" => "replace", "path" => "/a", "value" => 2} ]
+    
+    # When using atom keys, it cannot be patched successfully
+    assert {:error, _error, _desc} = JSONPatch.patch(a, patches)
+  end
 end


### PR DESCRIPTION
Hi, 

I modified the code to allow diff for atom keys, so the diff function works on structs too.

although such diffs cannot be patched back with the JSONPatch lib, it's still useful in many cases such as networked json data synchronization.

Regards, 
Lei
