### PR TITLE
Fix diffing Elixir dates

### DIFF
--- a/lib/json_diff.ex
+++ b/lib/json_diff.ex
@@ -151,6 +151,9 @@ defmodule JSONDiff do
   end
 
   @doc false
+  defp map_or_list?(%NaiveDateTime{}), do: false
+  defp map_or_list?(%DateTime{}), do: false
+  defp map_or_list?(%Date{}), do: false
   defp map_or_list?(a) when is_list(a) or is_map(a), do: true
   defp map_or_list?(_), do: false
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,8 @@
 %{
-  "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.20.1", "88eaa16e67c505664fd6a66f42ddb962d424ad68df586b214b71443c69887123", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "json_patch": {:hex, :json_patch, "0.8.0", "45c9fdaceb49739af3ab60196e2f2cc89b6e832e1ff2c1accf80432108b86777", [:mix], []},
-  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm", "e3be2bc3ae67781db529b80aa7e7c49904a988596e2dbff897425b48b3581161"},
+  "ex_doc": {:hex, :ex_doc, "0.20.1", "88eaa16e67c505664fd6a66f42ddb962d424ad68df586b214b71443c69887123", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "704b758b659a143f2f1b6f20cc3db2107a899c86c8485458ae2fcb0773651e59"},
+  "json_patch": {:hex, :json_patch, "0.8.0", "45c9fdaceb49739af3ab60196e2f2cc89b6e832e1ff2c1accf80432108b86777", [:mix], [], "hexpm", "ecc7c4a72388ae8907ccf3ec10f604da992214d5e535c18ba531009b1a77d0c7"},
+  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "5fbc8e549aa9afeea2847c0769e3970537ed302f93a23ac612602e805d9d1e7f"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "adf0218695e22caeda2820eaba703fa46c91820d53813a2223413da3ef4ba515"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm", "5c040b8469c1ff1b10093d3186e2e10dbe483cd73d79ec017993fb3985b8a9b3"},
 }

--- a/test/json_diff_test.exs
+++ b/test/json_diff_test.exs
@@ -141,6 +141,66 @@ defmodule JSONDiffTest do
     assert {:ok, ^b} = JSONPatch.patch(a, patches)
   end
 
+  test "it should generate replace for NaiveDateTime" do
+    now_a = NaiveDateTime.utc_now()
+    now_b = NaiveDateTime.add(now_a, 1, :minute)
+
+    a = %{"now" => now_a}
+    b = %{"now" => now_b}
+
+    result = [
+      %{
+        "op" => "replace",
+        "path" => "/now",
+        "value" => now_b
+      }
+    ]
+
+    patches = diff(a, b)
+
+    assert patches == result
+  end
+
+  test "it should generate replace for DateTime" do
+    now_a = DateTime.utc_now()
+    now_b = DateTime.add(now_a, 1, :minute)
+
+    a = %{"now" => now_a}
+    b = %{"now" => now_b}
+
+    result = [
+      %{
+        "op" => "replace",
+        "path" => "/now",
+        "value" => now_b
+      }
+    ]
+
+    patches = diff(a, b)
+
+    assert patches == result
+  end
+
+  test "it should generate replace for Date" do
+    now_a = Date.utc_today()
+    now_b = Date.add(now_a, 1)
+
+    a = %{"now" => now_a}
+    b = %{"now" => now_b}
+
+    result = [
+      %{
+        "op" => "replace",
+        "path" => "/now",
+        "value" => now_b
+      }
+    ]
+
+    patches = diff(a, b)
+
+    assert patches == result
+  end
+
   test "it should generate add" do
     a = %{
       "lastName" => "Einstein",
@@ -237,13 +297,13 @@ defmodule JSONDiffTest do
     assert {:ok, ^b} = JSONPatch.patch(a, patches)
   end
 
-  test "it should diff for atom keys" do 
+  test "it should diff for atom keys" do
     a = %{a: 1}
     b = %{a: 2}
-    
+
     patches = diff(a, b)
-    assert patches == [ %{"op" => "replace", "path" => "/a", "value" => 2} ]
-    
+    assert patches == [%{"op" => "replace", "path" => "/a", "value" => 2}]
+
     # When using atom keys, it cannot be patched successfully
     assert {:error, _error, _desc} = JSONPatch.patch(a, patches)
   end


### PR DESCRIPTION
Diffing is failing on values of NaiveDateTime, DateTime and Date. E.g.

```Elixir
iex(1)> a = %{"now" => NaiveDateTime.utc_now()}
%{"now" => ~N[2023-01-09 11:30:34.208557]}
iex(2)> b = %{"now" => NaiveDateTime.utc_now()}
%{"now" => ~N[2023-01-09 11:30:37.910756]}
iex(3)> JSONDiff.diff(a, b)
[
  %{"op" => "replace", "path" => "/now/second", "value" => 37},
  %{"op" => "replace", "path" => "/now/microsecond", "value" => {910756, 6}}
]
iex(4)>
```

As you can see it sets the path incorrectly.

This PR just adds a few function heads to not treat elixir dates as a map.